### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -2,6 +2,9 @@
 
 name: Node.js CI
 
+permissions:
+  contents: write
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/ScottSReynolds/next-js-test/security/code-scanning/1](https://github.com/ScottSReynolds/next-js-test/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, the `contents: read` permission is sufficient for most tasks, but the `Deploy` step (using `github-pages-deploy-action`) requires `contents: write` to push changes to the `gh-pages` branch. Therefore, we will set `contents: write` at the root level to cover all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
